### PR TITLE
Add possibility to initialize mq with hardcoded settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ settings := &config.Settings {
 	Scheme: "http",
 	Port: 8080,
 }
-queue := mq.New("test_queue", settings);
+queue := mq.ConfigNew("test_queue", settings);
 ```
 
 Push queues must be explicitly created. There's no changing a queue's type.

--- a/config/config.go
+++ b/config/config.go
@@ -59,10 +59,10 @@ func dbg(v ...interface{}) {
 	}
 }
 
-// Config gathers configuration from env variables and json config files.
+// ManualConfig gathers configuration from env variables and json config files.
 // Examples of fullProduct are "iron_worker", "iron_cache", "iron_mq" and
 // finally overwrites it with specified instance of Settings.
-func ConfigManually(fullProduct string, configuration *Settings) (settings Settings) {
+func ManualConfig(fullProduct string, configuration *Settings) (settings Settings) {
 	if os.Getenv("IRON_CONFIG_DEBUG") != "" {
 		debug = true
 		dbg("debugging of config enabled")
@@ -97,7 +97,7 @@ func ConfigManually(fullProduct string, configuration *Settings) (settings Setti
 // Config gathers configuration from env variables and json config files.
 // Examples of fullProduct are "iron_worker", "iron_cache", "iron_mq".
 func Config(fullProduct string) (settings Settings) {
-	return ConfigManually(fullProduct, nil)
+	return ManualConfig(fullProduct, nil)
 }
 
 func (s *Settings) globalConfig(family, product string) {
@@ -130,7 +130,7 @@ func (s *Settings) localConfig(family, product string) {
 }
 
 func (s *Settings) manualConfig(settings *Settings) {
-	if (settings != nil) {
+	if settings != nil {
 		s.UseSettings(settings)
 	}
 }

--- a/mq/mq.go
+++ b/mq/mq.go
@@ -103,7 +103,7 @@ func New(queueName string) Queue {
 // environment variables to return a Queue object capable of acquiring information about or 
 // modifying the queue specified by queueName.
 func ConfigNew(queueName string, settings *config.Settings) Queue {
-	return Queue{Settings: config.ConfigManually("iron_mq", settings), Name: queueName}
+	return Queue{Settings: config.ManualConfig("iron_mq", settings), Name: queueName}
 }
 
 // Will create a new queue, all fields are optional.


### PR DESCRIPTION
This feature is needed for migration swapi to v3. And of course there are another tasks where it probably could be used.
