### PR TITLE
Update touch signature

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,13 +280,26 @@ Touching a reserved message extends its timeout by the duration specified when t
 
 ```go
 msg, _ := q.Reserve()
-err := msg.Touch()
+err := msg.Touch() // new reservation id will be assigned to current message
 ```
 
 There is another way to touch a message without getting it:
 
 ```go
-err := q.TouchMessage("5987586196292186572")
+newReservationId, err := q.TouchMessage(messageId, reservationId)
+```
+
+#### Specifiying timeout
+
+```go
+msg, _ := q.Reserve()
+err := msg.TouchFor(10) // new reservation id will be assigned to current message
+```
+
+or
+
+```go
+newReservationId, err := q.TouchMessageFor(messageId, reservationId, 10)
 ```
 
 --

--- a/mq/mq.go
+++ b/mq/mq.go
@@ -418,7 +418,7 @@ func (q Queue) TouchMessageFor(msgId, reservationId string, timeout int) (string
 		Timeout       int    `json:"timeout,omitempty"`
 		ReservationId string `json:"reservation_id,omitempty"`
 	}{ReservationId: reservationId}
-	if (timeout > 0) {
+	if timeout > 0 {
 		in.Timeout = timeout
 	}
 	out := &Message{}


### PR DESCRIPTION
- Changed `Message` to `*Message` because we need to update `ReservationId`. If it's not good idea, I will change it back.
