### PR TITLE
Remove confusing comments

### DIFF
--- a/mq/mq.go
+++ b/mq/mq.go
@@ -291,7 +291,6 @@ func (q Queue) PeekN(n int) ([]Message, error) {
 		QueryAdd("n", "%d", n).
 		Req("GET", nil, &out)
 
-	// TODO there is a clever way to get rid of this
 	for i, _ := range out.Messages {
 		out.Messages[i].q = q
 	}
@@ -372,7 +371,6 @@ func (q Queue) LongPoll(n, timeout, wait int, delete bool) ([]Message, error) {
 
 	err := q.queues(q.Name, "reservations").Req("POST", &in, &out)
 
-	// TODO there is a clever way to get rid of this
 	for i, _ := range out.Messages {
 		out.Messages[i].q = q
 	}


### PR DESCRIPTION
We discussed these comments with @rdallman and decided that `json.Unmarsaler` (which initially implied to be here instead of the loop) can't help us here to implement elegant solution.