### PR TITLE
port necessary iron_go bits for worker

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -137,9 +137,12 @@ func (u *URL) Req(method string, in, out interface{}) error {
 
 // returned body must be closed by caller if non-nil
 func (u *URL) Request(method string, body io.Reader) (response *http.Response, err error) {
-	bytes, err := ioutil.ReadAll(body)
-	if err != nil {
-		return nil, err
+	var bytes []byte
+	if body != nil {
+		bytes, err = ioutil.ReadAll(body)
+		if err != nil {
+			return nil, err
+		}
 	}
 	return u.req(method, bytes)
 }

--- a/config/homedir.go
+++ b/config/homedir.go
@@ -1,0 +1,83 @@
+//The MIT License (MIT)
+
+//Copyright (c) 2013 Mitchell Hashimoto
+
+//Permission is hereby granted, free of charge, to any person obtaining a copy
+//of this software and associated documentation files (the "Software"), to deal
+//in the Software without restriction, including without limitation the rights
+//to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//copies of the Software, and to permit persons to whom the Software is
+//furnished to do so, subject to the following conditions:
+
+//The above copyright notice and this permission notice shall be included in
+//all copies or substantial portions of the Software.
+
+//THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//THE SOFTWARE.
+//
+// This file is a wholesale copy of https://github.com/mitchellh/go-homedir@1f6da4a72e57d4e7edd4a7295a585e0a3999a2d4
+// with Dir() renamed to homeDir() and Expand() deleted.
+package config
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"os/exec"
+	"runtime"
+	"strings"
+)
+
+// homeDir returns the home directory for the executing user.
+//
+// This uses an OS-specific method for discovering the home directory.
+// An error is returned if a home directory cannot be detected.
+func homeDir() (string, error) {
+	if runtime.GOOS == "windows" {
+		return dirWindows()
+	}
+
+	// Unix-like system, so just assume Unix
+	return dirUnix()
+}
+
+func dirUnix() (string, error) {
+	// First prefer the HOME environmental variable
+	if home := os.Getenv("HOME"); home != "" {
+		return home, nil
+	}
+
+	// If that fails, try the shell
+	var stdout bytes.Buffer
+	cmd := exec.Command("sh", "-c", "eval echo ~$USER")
+	cmd.Stdout = &stdout
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+
+	result := strings.TrimSpace(stdout.String())
+	if result == "" {
+		return "", errors.New("blank output when reading home directory")
+	}
+
+	return result, nil
+}
+
+func dirWindows() (string, error) {
+	drive := os.Getenv("HOMEDRIVE")
+	path := os.Getenv("HOMEPATH")
+	home := drive + path
+	if drive == "" || path == "" {
+		home = os.Getenv("USERPROFILE")
+	}
+	if home == "" {
+		return "", errors.New("HOMEDRIVE, HOMEPATH, and USERPROFILE are blank")
+	}
+
+	return home, nil
+}

--- a/worker/methods.go
+++ b/worker/methods.go
@@ -1,15 +1,8 @@
 package worker
 
 import (
-	"archive/zip"
-	"bytes"
-	"encoding/json"
 	"io/ioutil"
-	"mime/multipart"
-	"net/http"
 	"time"
-
-	"github.com/iron-io/iron_go3/api"
 )
 
 type Schedule struct {
@@ -23,6 +16,8 @@ type Schedule struct {
 	RunEvery       *int           `json:"run_every"`
 	RunTimes       *int           `json:"run_times"`
 	StartAt        *time.Time     `json:"start_at"`
+	Cluster        string         `json:"cluster"`
+	Label          string         `json:"label"`
 }
 
 type ScheduleInfo struct {
@@ -48,6 +43,8 @@ type Task struct {
 	Priority int            `json:"priority"`
 	Timeout  *time.Duration `json:"timeout"`
 	Delay    *time.Duration `json:"delay"`
+	Cluster  string         `json:"cluster"`
+	Label    string         `json:"label"`
 }
 
 type TaskInfo struct {
@@ -59,10 +56,12 @@ type TaskInfo struct {
 	Payload       string    `json:"payload"`
 	ProjectId     string    `json:"project_id"`
 	Status        string    `json:"status"`
+	Msg           string    `json:"msg,omitempty"`
 	ScheduleId    string    `json:"schedule_id"`
 	Duration      int       `json:"duration"`
 	RunTimes      int       `json:"run_times"`
 	Timeout       int       `json:"timeout"`
+	Percent       int       `json:"percent,omitempty"`
 	CreatedAt     time.Time `json:"created_at"`
 	UpdatedAt     time.Time `json:"updated_at"`
 	StartTime     time.Time `json:"start_time"`
@@ -72,10 +71,17 @@ type TaskInfo struct {
 type CodeSource map[string][]byte // map[pathInZip]code
 
 type Code struct {
-	Name     string
-	Runtime  string
-	FileName string
-	Source   CodeSource
+	Name           string        `json:"name"`
+	Runtime        string        `json:"runtime"`
+	FileName       string        `json:"file_name"`
+	Config         string        `json:"config,omitempty"`
+	MaxConcurrency int           `json:"max_concurrency,omitempty"`
+	Retries        int           `json:"retries,omitempty"`
+	Stack          string        `json:"stack"`
+	Image          string        `json:"image"`
+	Command        string        `json:"command"`
+	RetriesDelay   time.Duration `json:"-"`
+	Source         CodeSource    `json:"-"`
 }
 
 type CodeInfo struct {
@@ -84,7 +90,7 @@ type CodeInfo struct {
 	LatestHistoryId string    `json:"latest_history_id"`
 	Name            string    `json:"name"`
 	ProjectId       string    `json:"project_id"`
-	Runtime         string    `json:"runtime"`
+	Runtime         *string   `json:"runtime"`
 	Rev             int       `json:"rev"`
 	CreatedAt       time.Time `json:"created_at"`
 	UpdatedAt       time.Time `json:"updated_at"`
@@ -110,81 +116,6 @@ func (w *Worker) CodePackageList(page, perPage int) (codes []CodeInfo, err error
 	}
 
 	return out["codes"], nil
-}
-
-// CodePackageUpload uploads a code package
-func (w *Worker) CodePackageUpload(code Code) (id string, err error) {
-	body := &bytes.Buffer{}
-	mWriter := multipart.NewWriter(body)
-
-	// write meta-data
-	mMetaWriter, err := mWriter.CreateFormField("data")
-	if err != nil {
-		return
-	}
-	jEncoder := json.NewEncoder(mMetaWriter)
-	err = jEncoder.Encode(map[string]string{
-		"name":      code.Name,
-		"runtime":   code.Runtime,
-		"file_name": code.FileName,
-	})
-	if err != nil {
-		return
-	}
-
-	// write the zip
-	mFileWriter, err := mWriter.CreateFormFile("file", "worker.zip")
-	if err != nil {
-		return
-	}
-	zWriter := zip.NewWriter(mFileWriter)
-
-	for sourcePath, sourceText := range code.Source {
-		fWriter, err := zWriter.Create(sourcePath)
-		if err != nil {
-			return "", err
-		}
-		fWriter.Write([]byte(sourceText))
-	}
-
-	zWriter.Close()
-
-	// done with multipart
-	mWriter.Close()
-
-	req, err := http.NewRequest("POST", w.codes().URL.String(), body)
-	if err != nil {
-		return
-	}
-
-	req.Header.Set("Accept", "application/json")
-	req.Header.Set("Accept-Encoding", "gzip/deflate")
-	req.Header.Set("Authorization", "OAuth "+w.Settings.Token)
-	req.Header.Set("Content-Type", mWriter.FormDataContentType())
-	req.Header.Set("User-Agent", w.Settings.UserAgent)
-
-	// dumpRequest(req) NOTE: never do this here, it breaks stuff
-	response, err := http.DefaultClient.Do(req)
-	if err != nil {
-		return
-	}
-	if err = api.ResponseAsError(response); err != nil {
-		return
-	}
-
-	// dumpResponse(response)
-
-	data := struct {
-		Id         string `json:"id"`
-		Msg        string `json:"msg"`
-		StatusCode int    `json:"status_code"`
-	}{}
-	err = json.NewDecoder(response.Body).Decode(&data)
-	if err != nil {
-		return
-	}
-
-	return data.Id, err
 }
 
 // CodePackageInfo gets info about a code package
@@ -222,6 +153,50 @@ func (w *Worker) TaskList() (tasks []TaskInfo, err error) {
 	return out["tasks"], nil
 }
 
+type TaskListParams struct {
+	CodeName string
+	Page     int
+	PerPage  int
+	FromTime time.Time
+	ToTime   time.Time
+	Statuses []string
+}
+
+func (w *Worker) FilteredTaskList(params TaskListParams) (tasks []TaskInfo, err error) {
+	out := map[string][]TaskInfo{}
+	url := w.tasks()
+
+	url.QueryAdd("code_name", "%s", params.CodeName)
+
+	if params.Page > 0 {
+		url.QueryAdd("page", "%d", params.Page)
+	}
+
+	if params.PerPage > 0 {
+		url.QueryAdd("per_page", "%d", params.PerPage)
+	}
+
+	if fromTimeSeconds := params.FromTime.Unix(); fromTimeSeconds > 0 {
+		url.QueryAdd("from_time", "%d", fromTimeSeconds)
+	}
+
+	if toTimeSeconds := params.ToTime.Unix(); toTimeSeconds > 0 {
+		url.QueryAdd("to_time", "%d", toTimeSeconds)
+	}
+
+	for _, status := range params.Statuses {
+		url.QueryAdd(status, "%d", true)
+	}
+
+	err = url.Req("GET", nil, &out)
+
+	if err != nil {
+		return
+	}
+
+	return out["tasks"], nil
+}
+
 // TaskQueue queues a task
 func (w *Worker) TaskQueue(tasks ...Task) (taskIds []string, err error) {
 	outTasks := make([]map[string]interface{}, 0, len(tasks))
@@ -231,12 +206,14 @@ func (w *Worker) TaskQueue(tasks ...Task) (taskIds []string, err error) {
 			"code_name": task.CodeName,
 			"payload":   task.Payload,
 			"priority":  task.Priority,
+			"cluster":   task.Cluster,
+			"label":     task.Label,
 		}
 		if task.Timeout != nil {
 			thisTask["timeout"] = (*task.Timeout).Seconds()
 		}
 		if task.Delay != nil {
-			thisTask["delay"] = (*task.Delay).Seconds()
+			thisTask["delay"] = int64((*task.Delay).Seconds())
 		}
 
 		outTasks = append(outTasks, thisTask)
@@ -287,7 +264,15 @@ func (w *Worker) TaskCancel(taskId string) (err error) {
 }
 
 // TaskProgress sets a Task's Progress
-func (w *Worker) TaskProgress(taskId string, progress int) (err error) { return }
+func (w *Worker) TaskProgress(taskId string, progress int, msg string) (err error) {
+	payload := map[string]interface{}{
+		"msg":     msg,
+		"percent": progress,
+	}
+
+	err = w.tasks(taskId, "progress").Req("POST", payload, nil)
+	return
+}
 
 // TaskQueueWebhook queues a Task from a Webhook
 func (w *Worker) TaskQueueWebhook() (err error) { return }
@@ -311,6 +296,8 @@ func (w *Worker) Schedule(schedules ...Schedule) (scheduleIds []string, err erro
 			"code_name": schedule.CodeName,
 			"name":      schedule.Name,
 			"payload":   schedule.Payload,
+			"label":     schedule.Label,
+			"cluster":   schedule.Cluster,
 		}
 		if schedule.Delay != nil {
 			sm["delay"] = (*schedule.Delay).Seconds()

--- a/worker/remote.go
+++ b/worker/remote.go
@@ -4,20 +4,23 @@ import (
 	"encoding/json"
 	"flag"
 	"io"
+	"io/ioutil"
 	"os"
 )
 
 var (
-	taskDirFlag string
+	TaskDir     string
 	payloadFlag string
-	idFlag      string
+	TaskId      string
+	configFlag  string
 )
 
 // call this to parse flags before using the other methods.
 func ParseFlags() {
-	flag.StringVar(&taskDirFlag, "d", "", "task dir")
+	flag.StringVar(&TaskDir, "d", "", "task dir")
 	flag.StringVar(&payloadFlag, "payload", "", "payload file")
-	flag.StringVar(&idFlag, "id", "", "task id")
+	flag.StringVar(&TaskId, "id", "", "task id")
+	flag.StringVar(&configFlag, "config", "", "config file")
 	flag.Parse()
 }
 
@@ -34,6 +37,47 @@ func PayloadFromJSON(v interface{}) error {
 	return json.NewDecoder(reader).Decode(v)
 }
 
+func PayloadAsString() (string, error) {
+	reader, err := PayloadReader()
+	if err != nil {
+		return "", err
+	}
+	defer reader.Close()
+
+	b, err := ioutil.ReadAll(reader)
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
+}
+
+func ConfigReader() (io.ReadCloser, error) {
+	return os.Open(configFlag)
+}
+
+func ConfigFromJSON(v interface{}) error {
+	reader, err := ConfigReader()
+	if err != nil {
+		return err
+	}
+	defer reader.Close()
+	return json.NewDecoder(reader).Decode(v)
+}
+
+func ConfigAsString() (string, error) {
+	reader, err := ConfigReader()
+	if err != nil {
+		return "", err
+	}
+	defer reader.Close()
+
+	b, err := ioutil.ReadAll(reader)
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
+}
+
 func IronTaskId() string {
-	return idFlag
+	return TaskId
 }

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -2,10 +2,6 @@
 package worker
 
 import (
-	"fmt"
-	"io/ioutil"
-	"os"
-	"os/exec"
 	"time"
 
 	"github.com/iron-io/iron_go3/api"
@@ -29,7 +25,7 @@ func sleepBetweenRetries(previousDuration time.Duration) time.Duration {
 	if previousDuration >= 60*time.Second {
 		return previousDuration
 	}
-	return previousDuration * previousDuration
+	return previousDuration + previousDuration
 }
 
 var GoCodeRunner = []byte(`#!/bin/sh
@@ -46,63 +42,6 @@ chmod +x worker
 ./worker "$@"
 `)
 
-// NewGoCodePackage creates an IronWorker code package from a Go package.
-// The codeName is the name the code package will have have once it is uploaded.
-//
-// The packageArgs are equivalent to the args you would give to `go build`.
-//
-// If the packageArgs are a list of .go files, they will be treated as a list of
-// source files specifying a single Go package.
-//
-// Otherwise it's treated as a Go package name that will be searched in GOPATH,
-// and compiled.
-//
-// Please note that if you don't use `package main` for your Go package, this
-// function will not work as expected.
-func NewGoCodePackage(codeName string, packageArgs ...string) (code Code, err error) {
-	tempDir, err := ioutil.TempDir("", "iron-go-build-"+codeName)
-	if err != nil {
-		return
-	}
-
-	defer os.RemoveAll(tempDir)
-
-	os.Setenv("GOOS", "linux")
-	os.Setenv("GOARCH", "amd64")
-	args := []string{"build", "-x", "-v", "-o", tempDir + "/worker"}
-	cmd := exec.Command("go", append(args, packageArgs...)...)
-	output, err := cmd.CombinedOutput()
-
-	if err != nil {
-		fmt.Fprintln(os.Stderr, "vvvvvvvvvvvvvvvvvvvv go build output vvvvvvvvvvvvvvvvvvvv")
-		fmt.Fprintln(os.Stderr, string(output))
-		fmt.Fprintln(os.Stderr, "^^^^^^^^^^^^^^^^^^^^ go build output ^^^^^^^^^^^^^^^^^^^^")
-		return
-	}
-
-	fd, err := os.Open(tempDir + "/worker")
-	if err != nil {
-		return
-	}
-	defer fd.Close()
-	workerExe, err := ioutil.ReadAll(fd)
-	if err != nil {
-		return
-	}
-
-	code = Code{
-		Name:     codeName,
-		Runtime:  "sh",
-		FileName: "__runner__.sh",
-		Source: CodeSource{
-			"worker":        workerExe,
-			"__runner__.sh": GoCodeRunner,
-		},
-	}
-
-	return
-}
-
 // WaitForTask returns a channel that will receive the completed task and is closed afterwards.
 // If an error occured during the wait, the channel will be closed.
 func (w *Worker) WaitForTask(taskId string) chan TaskInfo {
@@ -118,8 +57,8 @@ func (w *Worker) WaitForTask(taskId string) chan TaskInfo {
 			}
 
 			if info.Status == "queued" || info.Status == "running" {
-				retryDelay = sleepBetweenRetries(retryDelay)
 				time.Sleep(retryDelay)
+				retryDelay = sleepBetweenRetries(retryDelay)
 			} else {
 				out <- info
 				return
@@ -142,8 +81,8 @@ func (w *Worker) WaitForTaskLog(taskId string) chan []byte {
 			if err != nil {
 				e, ok := err.(api.HTTPResponseError)
 				if ok && e.StatusCode() == 404 {
-					retryDelay = sleepBetweenRetries(retryDelay)
 					time.Sleep(retryDelay)
+					retryDelay = sleepBetweenRetries(retryDelay)
 					continue
 				}
 				return

--- a/worker/worker_test.go
+++ b/worker/worker_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	// "github.com/iron-io/iron_go3/worker"
+	// "github.com/iron-io/iron_go/worker"
 	. "github.com/jeffh/go.bdd"
 )
 


### PR DESCRIPTION
replaces #26 . tested this, it works for mq and worker and builds for icache (didn't touch api really). adds configuration of home dir stuff, reverts to using the old iron_go config methods that have env passed around and removes the 'newer' versions. the general interface is the same. `ManualConfig`, `Config` or `ConfigWithEnv`. i'm sure worker can be pruned more but porting this was task enough.

@bg451 looks ok? then we can vendor and get the mq stuff into cli (finally, my bad) 