### PR TITLE
assert that token and project_id are set and print a helpful error

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -117,6 +117,11 @@ func config(fullProduct, env string, configuration *Settings) Settings {
 	base.localConfig(family, product, env)
 	base.manualConfig(configuration)
 
+	if base.Token == "" || base.ProjectId == "" {
+		fmt.Println("Didn't find token or project_id in configs. Check your environment or iron.json.")
+		os.Exit(1)
+	}
+
 	return base
 }
 


### PR DESCRIPTION
closes #32 

this seems to happen quite a bit and many other libraries make this kind of assertion and exit. this library's message for not having a set project_id for instance gets a 301 from the service after attempting to make any request without a project_id set and is confusing to the user. 