### PR TITLE
Better handling of configuration errors

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -3,8 +3,8 @@ package config
 
 import (
 	"encoding/json"
-	"fmt"
 	"io/ioutil"
+	"log"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -54,7 +54,7 @@ var (
 
 func dbg(v ...interface{}) {
 	if debug {
-		fmt.Fprintln(os.Stderr, v...)
+		log.Println(v...)
 	}
 }
 
@@ -118,8 +118,7 @@ func config(fullProduct, env string, configuration *Settings) Settings {
 	base.manualConfig(configuration)
 
 	if base.Token == "" || base.ProjectId == "" {
-		fmt.Println("Didn't find token or project_id in configs. Check your environment or iron.json.")
-		os.Exit(1)
+		log.Panicln("Didn't find token or project_id in configs. Check your environment or iron.json.")
 	}
 
 	return base
@@ -128,7 +127,7 @@ func config(fullProduct, env string, configuration *Settings) Settings {
 func (s *Settings) globalConfig(family, product, env string) {
 	home, err := homeDir()
 	if err != nil {
-		fmt.Println("Error getting home directory:", err)
+		log.Println("Error getting home directory:", err)
 		return
 	}
 	path := filepath.Join(home, ".iron.json")


### PR DESCRIPTION
This change makes it easier for library users to handle configuration errors in their real applications.

* Use `log` package instead of hard-coded log destination.
  
  This allows library users to integrate error messages from this library with their own log destination or other log libraries like [`github.com/golang/glog`](https://github.com/golang/glog).
* Avoid directly terminating the current process with `os.Exit`.
  Use `panic` instead.
  
  In the original design with `os.Exit`, library users did not have any opportunity to cleanup resources (e.g. temporary files, HTTP session in other goroutines, ...) nor propagate the error message to the parent process.

NOTE: As explained in [Effective Go](https://golang.org/doc/effective_go.html#panic), usually it is better to avoid `panic` in libraries. But it is not covered in this commit because it requires incompatible signature change of `Config`, `ConfigWithEnv` and `ManualConfig` and forces library users to fix their applications.