### PR TITLE
Correct package godoc of iron-io/iron_go3/config

### DIFF
--- a/config/homedir.go
+++ b/config/homedir.go
@@ -1,17 +1,17 @@
 //The MIT License (MIT)
-
+//
 //Copyright (c) 2013 Mitchell Hashimoto
-
+//
 //Permission is hereby granted, free of charge, to any person obtaining a copy
 //of this software and associated documentation files (the "Software"), to deal
 //in the Software without restriction, including without limitation the rights
 //to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 //copies of the Software, and to permit persons to whom the Software is
 //furnished to do so, subject to the following conditions:
-
+//
 //The above copyright notice and this permission notice shall be included in
 //all copies or substantial portions of the Software.
-
+//
 //THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 //IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 //FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -22,6 +22,7 @@
 //
 // This file is a wholesale copy of https://github.com/mitchellh/go-homedir@1f6da4a72e57d4e7edd4a7295a585e0a3999a2d4
 // with Dir() renamed to homeDir() and Expand() deleted.
+
 package config
 
 import (


### PR DESCRIPTION
The blank line L25 is important.
The license declaration itself is not a part of package godoc. Currently only a part of the declaration is shown as a godoc.

c.f. https://godoc.org/github.com/iron-io/iron_go3/config