### PR TITLE
stream zip multipart upload

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -170,8 +170,7 @@ func (u *URL) req(method string, body io.ReadSeeker) (response *http.Response, e
 		return nil, err
 	}
 
-	// bytes.Buffer and bytes.Reader both implement `Len() int`, zip uses former, all else latter.
-	// if this changes for some reason, looky here
+	// body=bytes.Reader implements `Len() int`. if this changes for some reason, looky here
 	if s, ok := body.(interface {
 		Len() int
 	}); ok {
@@ -188,7 +187,11 @@ func (u *URL) req(method string, body io.ReadSeeker) (response *http.Response, e
 		request.Header.Set("Content-Type", "application/json")
 	}
 
-	request.Body = ioutil.NopCloser(body)
+	if rc, ok := body.(io.ReadCloser); ok { // stdlib doesn't have ReadSeekCloser :(
+		request.Body = rc
+	} else {
+		request.Body = ioutil.NopCloser(body)
+	}
 
 	dbg("URL:", request.URL.String())
 	dbg("request:", fmt.Sprintf("%#v\n", request))


### PR DESCRIPTION
previously we were loading the entire multipart zip and metadata into ram and
then uploading that. I was trying to make things blow up using a 1GB zip file
and succeeded in blowing up my own machine rather than a runner, so decided to
have a go at this (no pun).

uses io.Pipe and is safe for retries, I injected an error and tested that the
retries actually works and doesn't panic, etc, no guarantees but at least that
worked well. tested with an 800MB zip file and old vs this saves about 55
seconds (it took 4 minutes vs 5 minutes, 2 trials) and uses virtually no
memory, I sat at ~15 MB vs 800MB, which will be nice on our clients'
computers, too, though I haven't heard of any zip bombs to date.

should be able to use this technique in a few other spots, too..