### PR TITLE
Add the label param in FilteredTaskList

### DIFF
--- a/worker/methods.go
+++ b/worker/methods.go
@@ -316,6 +316,7 @@ func (w *Worker) TaskList() (tasks []TaskInfo, err error) {
 
 type TaskListParams struct {
 	CodeName string
+	Label    string
 	Page     int
 	PerPage  int
 	FromTime time.Time
@@ -328,6 +329,10 @@ func (w *Worker) FilteredTaskList(params TaskListParams) (tasks []TaskInfo, err 
 	url := w.tasks()
 
 	url.QueryAdd("code_name", "%s", params.CodeName)
+
+	if params.Label != "" {
+		url.QueryAdd("label", "%s", params.Label)
+	}
 
 	if params.Page > 0 {
 		url.QueryAdd("page", "%d", params.Page)


### PR DESCRIPTION
This pr add the label param in task, so we can make call like this:
/projects/{Project ID}/tasks?label={Taks label}

I added the if params.Label != "" so we don't have call like this with empty label:
/projects/{Project ID}/tasks?code_name=process_csv&label=&per_page=100