### PR TITLE
Fixed parsing retires count for subscribers

### DIFF
--- a/mq/mq.go
+++ b/mq/mq.go
@@ -78,7 +78,7 @@ type PushStatus struct {
 }
 
 type Subscriber struct {
-	Retried    int    `json:"retried"`
+	Retried    int    `json:"tries"`
 	StatusCode int    `json:"status_code"`
 	Status     string `json:"status"`
 	URL        string `json:"url"`

--- a/mq/mq.go
+++ b/mq/mq.go
@@ -71,12 +71,6 @@ type Message struct {
 	q             Queue     // todo: shouldn't this be a pointer?
 }
 
-type PushStatus struct {
-	Retried    int    `json:"retried"`
-	StatusCode int    `json:"status_code"`
-	Status     string `json:"status"`
-}
-
 type Subscriber struct {
 	Retried    int    `json:"tries"`
 	StatusCode int    `json:"status_code"`


### PR DESCRIPTION
API request to `/3/projects/<project>/queues/<queue>/messages/<message_ID>/subscribers` provides JSON that looks like following: 

```
{
	"subscribers": [{
		"subscriber_name": "sub1",
		"url": "http://227.0.0.1:8888",
		"retries_remaining": 2,
		"tries": 1,
		"last_try_at": "2017-11-23T14:38:05.399510973+06:00",
		"status_code": 500,
		"msg": "error pushing: Post http://227.0.0.1:8888: dial tcp 227.0.0.1:8888: connect: network is unreachable"
	}]
}
```

But client library is looking for a `retried` field. As a result client library returns 0 in retries count.

This PR is fixing it.  